### PR TITLE
Initialize Tauri + Svelte skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# worecorder
+# Worecorder
+
+This project uses **Tauri** with a **Svelte** frontend. It provides the basic
+scaffold for building a desktop application.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>worecorder</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "worecorder",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "tauri": "tauri dev"
+  }
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "worecorder"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "1", features = ["api-all"] }
+
+[build-dependencies]
+tauri-build = { version = "1", features = ["config-json"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,7 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+  tauri::Builder::default()
+    .run(tauri::generate_context!())
+    .expect("error while running tauri application");
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,17 @@
+{
+  "build": {
+    "beforeDevCommand": "npm run dev",
+    "beforeBuildCommand": "npm run build",
+    "devPath": "http://localhost:5173",
+    "distDir": "../dist"
+  },
+  "package": {
+    "productName": "worecorder",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "bundle": {
+      "identifier": "com.example.worecorder"
+    }
+  }
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,0 +1,14 @@
+<script>
+  let name = 'world';
+</script>
+
+<main>
+  <h1>Hello {name}!</h1>
+</main>
+
+<style>
+  main {
+    text-align: center;
+    padding: 1em;
+  }
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,7 @@
+import App from './App.svelte';
+
+const app = new App({
+  target: document.getElementById('app') as HTMLElement,
+});
+
+export default app;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess(),
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()],
+});


### PR DESCRIPTION
## Summary
- set up Tauri with Svelte placeholders
- add minimal Rust backend for Tauri
- provide basic Vite/Svelte frontend

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: failed to download from crates.io)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6856abffa51c83238b9497f9350f0d80