### PR TITLE
Fix vite script failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,11 @@
     "dev": "vite",
     "build": "vite build",
     "tauri": "tauri dev"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^2.0.0",
+    "svelte": "^3.59.2",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add required dev dependencies for vite and svelte

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*
- `npm run build` *(fails: vite: not found because install failed)*

------
https://chatgpt.com/codex/tasks/task_e_6856be645e2483238dcc1ad76f8a25f8